### PR TITLE
Add new Homebrew path and fix security concern

### DIFF
--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -296,6 +296,8 @@ tell application "Finder"
 		set lpass_binary to "/usr/local/bin/lpass"
 	else if exists POSIX file "/opt/local/bin/lpass" then
 		set lpass_binary to "/opt/local/bin/lpass"
+	else if exists POSIX file "/opt/homebrew/bin/lpass" then
+		set lpass_binary to "/opt/homebrew/bin/lpass"
 	end if
 end tell
 
@@ -305,7 +307,7 @@ if ("{query}" = "scriptlocationnotset") then
 display notification "Please wait... the alfred search will be presented once login is complete." with title "LastPass Login"
 end if
 
-do shell script "/bin/bash -c '" &amp; "export TERM=\"xterm-256color\" &amp;&amp; export LPASS_ASKPASS=\"" &amp; osascript &amp; "\" &amp;&amp; export LPASS_AGENT_TIMEOUT=" &amp; login_timeout &amp; " &amp;&amp; " &amp; lpass_binary &amp; " login --trust \"" &amp; login_email &amp; "\" &amp;&amp; clear &amp;&amp; " &amp; lpass_binary &amp; " ls --sync=now &gt; /dev/null 2&gt;&amp;1 &amp;&amp; exit 0'"
+do shell script "/bin/bash -c '" &amp; "export TERM=\"xterm-256color\" &amp;&amp; export LPASS_ASKPASS=\"" &amp; osascript &amp; "\" &amp;&amp; export LPASS_AGENT_TIMEOUT=" &amp; login_timeout &amp; " &amp;&amp; " &amp; lpass_binary &amp; " login \"" &amp; login_email &amp; "\" &amp;&amp; clear &amp;&amp; " &amp; lpass_binary &amp; " ls --sync=now &gt; /dev/null 2&gt;&amp;1 &amp;&amp; exit 0'"
 
 if ("{query}" = "scriptlocationnotset") then
 tell application id "com.runningwithcrayons.Alfred" to search "lp "
@@ -407,7 +409,7 @@ exit 1;
 } else {
 
 my $lpass_exec;
-foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
+foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass /opt/homebrew/bin/lpass@) {
     $lpass_exec = $f
         if (-x $f);
 }
@@ -530,7 +532,7 @@ my ($agent, $agentErr, $agentErrCode) = capture {
 };
 
 my $lpass_exec;
-foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
+foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass /opt/homebrew/bin/lpass@) {
     $lpass_exec = $f
         if (-x $f);
 }
@@ -669,7 +671,7 @@ exit 1;
 } else {
 
 my $lpass_exec;
-foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
+foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass /opt/homebrew/bin/lpass@) {
     $lpass_exec = $f
         if (-x $f);
 }
@@ -768,7 +770,7 @@ print $results;
 				<integer>127</integer>
 				<key>script</key>
 				<string>#!/bin/bash
-for f in lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass; do
+for f in lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass /opt/homebrew/bin/lpass; do
     if test -x $f; then
         lpass_exec=$f
     fi
@@ -827,7 +829,7 @@ my ($agent, $agentErr, $agentErrCode) = capture {
 };
 
 my $lpass_exec;
-foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
+foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass /opt/homebrew/bin/lpass@) {
     $lpass_exec = $f
         if (-x $f);
 }


### PR DESCRIPTION
Homebrew switched to use `/opt/homebrew/bin` as default path now. Add this path to binary findings.

Remove the `--trust` option from the login command, since this will remove the multifactor option.

```
The 'login' subcommand will initialize a local cache and configuration folder,
then attempt to authenticate itself with the LastPass servers, using the
provided command line credentials or by interactively prompting (in the case of
multifactor or an unprovided password). The '--trust' option will cause
subsequent logins to not require multifactor authentication. If the
'--plaintext-key' option is specified, the decryption key will be saved to the
hard disk in plaintext.  Please note that use of this option is discouraged
except in limited situations, as it greatly decreases the security of data.
```